### PR TITLE
curlyout regex should match entire line

### DIFF
--- a/pan_indent_checker.py
+++ b/pan_indent_checker.py
@@ -114,7 +114,7 @@ def main():
                 cleanline = RE_COMMENT.sub('# IGNORED COMMENT', cleanline)
                 startmatch = re.findall(r'[{(]', cleanline)
                 endmatch = re.findall(r'[})]', cleanline)
-                curlyout = re.search(r'(^[)}])(.*)([{(])', cleanline)
+                curlyout = re.search(r'(^[)}])(.*)([{(]$)', cleanline)
                 if args.debug:
                     _print_debug("Cleaned line", cleanline)
 


### PR DESCRIPTION
This is a special case for handling things like `} else {` and `) with {` and shouldn't allow code to continue after it.